### PR TITLE
Use integers for percentage rates

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -47,12 +47,12 @@ const industryStandards = {
   revenueTarget: 50000,
   salePrice: 10000,
   haveSalesCall: true,
-  salesCallConversionRate: 0.2,
-  cancellationRate: 0.3,
-  callBookingConversionRate: 0.05,
-  registrationPageConversionRate: 0.2,
+  salesCallConversionRate: 20,
+  cancellationRate: 30,
+  callBookingConversionRate: 5,
+  registrationPageConversionRate: 20,
   cpc: 1,
-  ctr: 0.01,
+  ctr: 1,
 };
 
 const MainContent = styled.div`

--- a/src/Input.js
+++ b/src/Input.js
@@ -5,9 +5,7 @@ import PropTypes from "prop-types";
 const Input = ({ onChange, value, label, type }) => {
   return (
     <InputForm inputType={type}>
-      <div className="input-label">
-        {label}
-      </div>
+      <div className="input-label">{label}</div>
       <input
         type="text"
         className="input"
@@ -23,6 +21,7 @@ Input.propTypes = {
   onChange: PropTypes.func.isRequired,
   value: PropTypes.number.isRequired,
   label: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
 };
 
 export default Input;
@@ -85,4 +84,4 @@ const InputForm = styled.div`
       border-color: #b0bec5;
     }
   }
-`; 
+`;

--- a/src/Results.js
+++ b/src/Results.js
@@ -154,4 +154,7 @@ const ResultHeader = styled.h2`
 `;
 
 const asCurrency = num =>
-  num.toLocaleString("en", { minimumFractionDigits: 2 });
+  num.toLocaleString("en", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });

--- a/src/Results.js
+++ b/src/Results.js
@@ -118,21 +118,22 @@ export default Results;
 
 const salesRequired = (revGoal, salePrice) => Math.ceil(revGoal / salePrice);
 const preNoShowSalesCallsNeeded = (salesRequired, salesCallConversionRate) =>
-  Math.ceil(salesRequired / salesCallConversionRate);
+  Math.ceil(salesRequired / asPct(salesCallConversionRate));
 const salesCallesNeeded = (preCount, cancellationRate) =>
-  Math.ceil(preCount / (1 - cancellationRate));
+  Math.ceil(preCount / (1 - asPct(cancellationRate)));
 const registrantsNeeded = (salesCallCount, callBookingConversionRate) =>
-  Math.ceil(salesCallCount / callBookingConversionRate);
+  Math.ceil(salesCallCount / asPct(callBookingConversionRate));
 const landingPageViewsNeeded = (
   registrantCount,
   registrationPageConversionRate
-) => Math.ceil(registrantCount / registrationPageConversionRate);
+) => Math.ceil(registrantCount / asPct(registrationPageConversionRate));
 const reachRequired = (landingPageViews, ctr) =>
-  Math.ceil(landingPageViews / ctr);
+  Math.ceil(landingPageViews / asPct(ctr));
 const adSpendRequired = (landingPageViews, cpc) => landingPageViews * cpc;
 const costPerCall = (adSpend, callsNeeded) => adSpend / callsNeeded;
 const totalRevenue = (salePrice, sales) => salePrice * sales;
 const returnOnAdSpend = (rev, adSpend) => rev / adSpend;
+const asPct = rate => rate / 100.0;
 
 const ResultCard = styled.div`
   background-color: #0e143e;

--- a/src/__snapshots__/RadioButton.test.js.snap
+++ b/src/__snapshots__/RadioButton.test.js.snap
@@ -3,7 +3,7 @@
 exports[`matches design when an item is not selected 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdnylx hwoZWL"
+    class="sc-bdnylx dEyZuN"
   >
     <label
       class="container"
@@ -20,7 +20,7 @@ exports[`matches design when an item is not selected 1`] = `
     </label>
   </div>
   <div
-    class="sc-bdnylx hwoZWL"
+    class="sc-bdnylx dEyZuN"
   >
     <label
       class="container"
@@ -42,7 +42,7 @@ exports[`matches design when an item is not selected 1`] = `
 exports[`matches design when an item is selected 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdnylx hwoZWL"
+    class="sc-bdnylx dEyZuN"
   >
     <label
       class="container checked"
@@ -60,7 +60,7 @@ exports[`matches design when an item is selected 1`] = `
     </label>
   </div>
   <div
-    class="sc-bdnylx hwoZWL"
+    class="sc-bdnylx dEyZuN"
   >
     <label
       class="container"


### PR DESCRIPTION
Fixes [this To Do](https://3.basecamp.com/3097764/buckets/19037960/todos/3088901198)

### Testing notes

1. Open the site and see the rate inputs as integers (e.g. 20 instead of 0.2).
1. Update any percentage as an integer and see the calculations compute
   properly.


### Other information
