### PR TITLE
Make strategy calls optional

### DIFF
--- a/src/ResultItem.js
+++ b/src/ResultItem.js
@@ -5,7 +5,11 @@ import styled from "styled-components";
 import CheckGreen from "./check-green.svg";
 import CheckGrey from "./check-grey.svg";
 
-const ResultItem = ({ completed, label, value, description }) => {
+const ResultItem = ({ completed, label, value, description, show }) => {
+  if (!show) {
+    return null;
+  }
+
   return (
     <Item completed={completed}>
       <span className="completed">
@@ -27,6 +31,11 @@ ResultItem.propTypes = {
   label: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,
   description: PropTypes.string,
+  show: PropTypes.bool,
+};
+
+ResultItem.defaultProps = {
+  show: true,
 };
 
 export default ResultItem;

--- a/src/Results.js
+++ b/src/Results.js
@@ -48,8 +48,9 @@ const Results = ({
     },
     {
       completed: isComplete(completion, "cancellationRate"),
-      label: "Sales calls needed",
+      label: "Strategy calls needed",
       value: Math.ceil(totalsSalesCallCount).toLocaleString("en"),
+      show: haveSalesCall,
     },
     {
       completed: isComplete(completion, "callBookingConversionRate"),
@@ -77,6 +78,7 @@ const Results = ({
       completed: isComplete(completion, "cpc"),
       label: "Cost per strategy call",
       value: asCurrency(eachCallCost),
+      show: haveSalesCall,
     },
     {
       completed: isComplete(completion, "salePrice"),

--- a/src/Results.js
+++ b/src/Results.js
@@ -27,7 +27,7 @@ const Results = ({
     cancellationRate
   );
   const registrantCount = registrantsNeeded(
-    totalsSalesCallCount,
+    haveSalesCall ? totalsSalesCallCount : salesReq,
     callBookingConversionRate
   );
   const landingViews = landingPageViewsNeeded(

--- a/src/StrategyCalls.js
+++ b/src/StrategyCalls.js
@@ -21,7 +21,9 @@ const StrategyCalls = ({ inputs, handleInput, completion }) => {
           id="have_sales_call"
           value={inputs.haveSalesCall ? "Yes" : "No"}
           options={["Yes", "No"]}
-          onChange={v => handleInput("haveSalesCall")(v === "Yes")}
+          onChange={e =>
+            handleInput("haveSalesCall")(e.target.value === "Yes")
+          }
         />
       </RadioContainer>
       <Input

--- a/src/StrategyCalls.js
+++ b/src/StrategyCalls.js
@@ -14,9 +14,7 @@ const StrategyCalls = ({ inputs, handleInput, completion }) => {
       <h2>Strategy Calls</h2>
 
       <RadioContainer>
-        <label htmlFor="have_sales_call">
-          Have a strategy call?
-        </label>
+        <label htmlFor="have_sales_call">Have a strategy call?</label>
         <RadioButton
           id="have_sales_call"
           value={inputs.haveSalesCall ? "Yes" : "No"}

--- a/src/__snapshots__/RadioButton.test.js.snap
+++ b/src/__snapshots__/RadioButton.test.js.snap
@@ -3,7 +3,7 @@
 exports[`matches design when an item is not selected 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdnylx hwoZWL"
+    class="sc-bdnylx dEyZuN"
   >
     <label
       class="container"
@@ -20,7 +20,7 @@ exports[`matches design when an item is not selected 1`] = `
     </label>
   </div>
   <div
-    class="sc-bdnylx hwoZWL"
+    class="sc-bdnylx dEyZuN"
   >
     <label
       class="container"
@@ -42,7 +42,7 @@ exports[`matches design when an item is not selected 1`] = `
 exports[`matches design when an item is selected 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdnylx hwoZWL"
+    class="sc-bdnylx dEyZuN"
   >
     <label
       class="container checked"
@@ -60,7 +60,7 @@ exports[`matches design when an item is selected 1`] = `
     </label>
   </div>
   <div
-    class="sc-bdnylx hwoZWL"
+    class="sc-bdnylx dEyZuN"
   >
     <label
       class="container"

--- a/src/completion.js
+++ b/src/completion.js
@@ -1,6 +1,5 @@
 export const newCompletionFor = (currentCompletion, field) => {
   const newCompletion = completionFor(field);
-  console.log(field, newCompletion);
 
   if (newCompletion < currentCompletion) {
     return currentCompletion;


### PR DESCRIPTION
Fixes [this To Do](https://3.basecamp.com/3097764/buckets/19037960/todos/3091719301)

### Testing notes

1. Toggle Have a strategy call to No.
1. The "Strategy calls needed" and "Cost per strategy call" results disappear.
1. The registrands needed is now sales needed divided by registration page
   conversion rate.


### Other information
