### PR TITLE
Focus revenue target on page load

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -13,6 +13,7 @@ const Input = ({ onChange, value, label, type, focus }) => {
         value={value === 0 ? "" : value}
         onChange={e => onChange(e.target.value)}
         autoFocus={focus}
+        onFocus={e => e.currentTarget.select()}
       ></input>
     </InputForm>
   );

--- a/src/Input.js
+++ b/src/Input.js
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 
-const Input = ({ onChange, value, label, type }) => {
+const Input = ({ onChange, value, label, type, focus }) => {
   return (
     <InputForm inputType={type}>
       <div className="input-label">{label}</div>
@@ -12,6 +12,7 @@ const Input = ({ onChange, value, label, type }) => {
         id="input-form"
         value={value === 0 ? "" : value}
         onChange={e => onChange(e.target.value)}
+        autoFocus={focus}
       ></input>
     </InputForm>
   );
@@ -22,6 +23,11 @@ Input.propTypes = {
   value: PropTypes.number.isRequired,
   label: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
+  focus: PropTypes.bool,
+};
+
+Input.defaultProps = {
+  focus: false,
 };
 
 export default Input;

--- a/src/RevenueGoals.js
+++ b/src/RevenueGoals.js
@@ -15,6 +15,7 @@ const RevenueGoals = ({ inputs, handleInput, completion }) => {
         value={inputs.revenueTarget}
         onChange={asFloat(handleInput("revenueTarget"))}
         label="Revenue target"
+        focus={true}
       />
       <Input
         type="number"


### PR DESCRIPTION
### Testing notes

1. Load the page.
1. See revenue target as focus.
1. Hit Tab.
1. See that all of the sale price input is selected for easy replacement.


### Other information
