### PR TITLE
Divide average component

### DIFF
--- a/src/AveragesList.js
+++ b/src/AveragesList.js
@@ -2,7 +2,7 @@ import styled from "styled-components";
 
 const AveragesList = styled.div`
 color: #263238;
-> div {
+div {
   margin-left: -1rem;
   padding: 0 1rem;
   font-size: 14px;

--- a/src/AveragesList.js
+++ b/src/AveragesList.js
@@ -1,0 +1,28 @@
+import styled from "styled-components";
+
+const AveragesList = styled.div`
+color: #263238;
+> div {
+  margin-left: -1rem;
+  padding: 0 1rem;
+  font-size: 14px;
+}
+div {
+  height: 40px;
+  line-height: 40px;
+}
+div:nth-child(2n+2) {
+  height: 32px;
+  line-height: 32px;
+  background-color: #F9FAFA;
+}
+
+span {
+  float: right;
+  font-size: 14px;
+  font-weight: bold;
+  text-align: right;
+}
+`;
+
+export default AveragesList;

--- a/src/HighAverages.js
+++ b/src/HighAverages.js
@@ -13,21 +13,17 @@ const HighAverages = () => {
     { "Email open rate": "2%" }
   ]
 
-  function makeRows() {
-    let row = [];
-    highAvgs.forEach((obj) => {
-      Object.keys(obj).forEach((key) => {
-        row.push(<div key={key}>{key}<span>{obj[key]}</span></div>)
-      })
+  let rows = [];
+  highAvgs.forEach((obj) => {
+    Object.keys(obj).forEach((key) => {
+      rows.push(<div key={key}>{key}<span>{obj[key]}</span></div>)
     })
-    return (
-      <div>{row}</div>
-    )
-  }
+  })
+
 
   return (
     <AveragesList>
-      {makeRows()}
+      <div>{rows}</div>
     </AveragesList>
   )
 

--- a/src/HighAverages.js
+++ b/src/HighAverages.js
@@ -1,0 +1,36 @@
+import React from "react";
+import AveragesList from "./AveragesList";
+
+const HighAverages = () => {
+  const highAvgs = [
+    { "Top of funnel CTR": "1%" },
+    { "Middle/bottom of funnel CTR": "2 - 4%" },
+    { "Webinar optin page conversion rate": "20%" },
+    { "Live webinar attendee rate": "10%" },
+    { "Live webinar conversion rate to booked call": "5%" },
+    { "Evergreen webinar attendee rate": "60%" },
+    { "Evergreen webinar conversion rate to booked call": "5%" },
+    { "Email open rate": "2%" }
+  ]
+
+  function makeRows() {
+    let row = [];
+    highAvgs.forEach((obj) => {
+      Object.keys(obj).forEach((key) => {
+        row.push(<div key={key}>{key}<span>{obj[key]}</span></div>)
+      })
+    })
+    return (
+      <div>{row}</div>
+    )
+  }
+
+  return (
+    <AveragesList>
+      {makeRows()}
+    </AveragesList>
+  )
+
+}
+
+export default HighAverages;

--- a/src/IndustryAverages.js
+++ b/src/IndustryAverages.js
@@ -1,18 +1,19 @@
 import React from "react";
 import styled from "styled-components";
-import Averages from "./Averages";
+import LowAverages from "./LowAverages";
+import HighAverages from "./HighAverages";
 
 const IndustryAverages = () => {
   return (
     <IndustryAveragesContent>
       <h2>Industry averages</h2>
       <div className="col">
-        <h3>Strategy call funnel stats</h3>
-        <Averages type="high" />
+        <h3>High ticket webinar coaching stats</h3>
+        <HighAverages />
       </div>
       <div className="col">
-        <h3>No strategy call funnel stats</h3>
-        <Averages type="low" />
+        <h3>Low ticket webinar coaching stats</h3>
+        <LowAverages />
       </div>
     </IndustryAveragesContent>
   );

--- a/src/LowAverages.js
+++ b/src/LowAverages.js
@@ -12,21 +12,16 @@ const LowAverages = () => {
     { "Email open rate": "2%" }
   ]
 
-  function makeRows() {
-    let row = [];
-    lowAvgs.forEach((obj) => {
-      Object.keys(obj).forEach((key) => {
-        row.push(<div key={key}>{key}<span>{obj[key]}</span></div>)
-      })
+  let rows = [];
+  lowAvgs.forEach((obj) => {
+    Object.keys(obj).forEach((key) => {
+      rows.push(<div key={key}>{key}<span>{obj[key]}</span></div>)
     })
-    return (
-      <div>{row}</div>
-    )
-  }
+  })
 
   return (
     <AveragesList>
-      {makeRows()}
+      {rows}
     </AveragesList>
   )
 

--- a/src/LowAverages.js
+++ b/src/LowAverages.js
@@ -1,0 +1,35 @@
+import React from "react";
+import AveragesList from "./AveragesList";
+
+const LowAverages = () => {
+  const lowAvgs = [
+    { "Top of funnel CTR": "1%" },
+    { "Middle/bottom of funnel CTR": "2 - 4%" },
+    { "Lead magnet optin page conversion rate": "20%" },
+    { "Webinar attendee rate": "5 - 20%" },
+    { "Sales page add-to-cart rate": "16 - 20%" },
+    { "Sales page conversion rate": "5%" },
+    { "Email open rate": "2%" }
+  ]
+
+  function makeRows() {
+    let row = [];
+    lowAvgs.forEach((obj) => {
+      Object.keys(obj).forEach((key) => {
+        row.push(<div key={key}>{key}<span>{obj[key]}</span></div>)
+      })
+    })
+    return (
+      <div>{row}</div>
+    )
+  }
+
+  return (
+    <AveragesList>
+      {makeRows()}
+    </AveragesList>
+  )
+
+}
+
+export default LowAverages;


### PR DESCRIPTION
Fixes [this To Do]()

### Testing notes

1. This compounds on [branch](https://github.com/growthtools/ad-spend-calc/pull/18) add-industry-avg-card. It simplifies the Averages component by creating two different components, Low and High component.



### Other information
